### PR TITLE
update ruby-node's version v2.4.7 to v2.4.7-12.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/palettecloud/ruby-node:v2.4.7
+FROM quay.io/palettecloud/ruby-node:v2.4.7-12.13.0
 LABEL maintainer "hiroyuki nikaido <nikadon@palette.cloud>"
 
 RUN apt-get update


### PR DESCRIPTION
# ruby-nodeのバージョンアップ
ruby-nodeイメージのバージョンアップに伴い対応するバージョンを作成
