### PR TITLE
feature/3.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/palettecloud/ruby-node:pr-17
+FROM ghcr.io/palettecloud/ruby-node:pr-18
 LABEL maintainer "hiroyuki nikaido <nikadon@palette.cloud>"
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/palettecloud/ruby-node:pr-18
+FROM palettecloud/ruby-node:v3.1.6-12.13.0
 LABEL maintainer "hiroyuki nikaido <nikadon@palette.cloud>"
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM palettecloud/ruby-node:v2.7.6-12.13.0
+FROM ghcr.io/palettecloud/ruby-node:pr-17
 LABEL maintainer "hiroyuki nikaido <nikadon@palette.cloud>"
 
 RUN apt-get update


### PR DESCRIPTION
ベースイメージを palettecloud/ruby-node:v3.1.6-12.13.0 に変更します。
付与予定のタグは palettecloud/ruby-cron:v3.1.6-12.13.0-tini